### PR TITLE
More server tweaks

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -6,11 +6,11 @@ import (
 	"os"
 	"time"
 
+	"github.com/b2aio/typhon/rabbit"
 	log "github.com/cihub/seelog"
 	"github.com/golang/protobuf/proto"
 	"github.com/nu7hatch/gouuid"
 	"github.com/streadway/amqp"
-	"github.com/vinceprignano/bunny/rabbit"
 )
 
 type Client interface {

--- a/example/handler/hello.go
+++ b/example/handler/hello.go
@@ -4,8 +4,9 @@ import (
 	"fmt"
 
 	"github.com/golang/protobuf/proto"
-	"github.com/vinceprignano/bunny/example/proto/hello"
-	"github.com/vinceprignano/bunny/server"
+
+	"github.com/b2aio/typhon/example/proto/hello"
+	"github.com/b2aio/typhon/server"
 )
 
 // Hello is a handler that responds to a hello request with a greeting

--- a/example/handler/hello.go
+++ b/example/handler/hello.go
@@ -10,7 +10,7 @@ import (
 )
 
 // Hello is a handler that responds to a hello request with a greeting
-func Hello(req server.Request) (proto.Message, error) {
+func Hello(req server.Request) (server.Response, error) {
 
 	// Unmarshal our request
 	f := &hello.Request{}
@@ -24,9 +24,9 @@ func Hello(req server.Request) (proto.Message, error) {
 	// Do something here
 
 	// Build response
-	resp := &hello.Response{
+	resp := server.NewProtoResponse(&hello.Response{
 		Greeting: proto.String(fmt.Sprintf("Hello, %s!", name)),
-	}
+	})
 
 	return resp, nil
 }

--- a/example/handler/hello.go
+++ b/example/handler/hello.go
@@ -8,8 +8,10 @@ import (
 	"github.com/vinceprignano/bunny/server"
 )
 
-func HelloHandler(req server.Request) (proto.Message, error) {
+// Hello is a handler that responds to a hello request with a greeting
+func Hello(req server.Request) (proto.Message, error) {
 
+	// Unmarshal our request
 	f := &hello.Request{}
 	if err := proto.Unmarshal(req.Body(), f); err != nil {
 		return nil, fmt.Errorf("Count not unmarshal request")

--- a/example/main.go
+++ b/example/main.go
@@ -23,8 +23,8 @@ func main() {
 
 	// Register an example endpoint
 	server.RegisterEndpoint(&server.DefaultEndpoint{
-		EndpointName: "sayhello",           // Routing Key
-		Handler:      handler.HelloHandler, // HandlerFunc
+		EndpointName: "sayhello",    // Routing Key
+		Handler:      handler.Hello, // HandlerFunc
 	})
 
 	// Fire off a request to be sent back to us in 1 second

--- a/example/main.go
+++ b/example/main.go
@@ -15,8 +15,8 @@ import (
 // main is the definition of our server
 func main() {
 
-	// Initialise our Server
-	server.Initialise(&server.Config{
+	// Initialize our Server
+	server.Init(&server.Config{
 		Name:        "helloworld",
 		Description: "Demo service which replies to a name with a greeting",
 	})

--- a/example/main.go
+++ b/example/main.go
@@ -3,13 +3,13 @@ package main
 import (
 	"time"
 
+	"github.com/b2aio/typhon/client"
+	"github.com/b2aio/typhon/server"
 	log "github.com/cihub/seelog"
 	"github.com/golang/protobuf/proto"
-	"github.com/vinceprignano/bunny/client"
-	"github.com/vinceprignano/bunny/server"
 
-	"github.com/vinceprignano/bunny/example/handler"
-	"github.com/vinceprignano/bunny/example/proto/hello"
+	"github.com/b2aio/typhon/example/handler"
+	"github.com/b2aio/typhon/example/proto/hello"
 )
 
 // main is the definition of our server

--- a/server/endpoint.go
+++ b/server/endpoint.go
@@ -1,21 +1,19 @@
 package server
 
-import "github.com/golang/protobuf/proto"
-
 type Endpoint interface {
 	Name() string
-	HandleRequest(req Request) (proto.Message, error)
+	HandleRequest(req Request) (Response, error)
 }
 
 type DefaultEndpoint struct {
 	EndpointName string
-	Handler      func(req Request) (proto.Message, error)
+	Handler      func(req Request) (Response, error)
 }
 
 func (d *DefaultEndpoint) Name() string {
 	return d.EndpointName
 }
 
-func (d *DefaultEndpoint) HandleRequest(req Request) (proto.Message, error) {
+func (d *DefaultEndpoint) HandleRequest(req Request) (Response, error) {
 	return d.Handler(req)
 }

--- a/server/rabbitmq.go
+++ b/server/rabbitmq.go
@@ -13,7 +13,7 @@ import (
 	"github.com/vinceprignano/bunny/rabbit"
 )
 
-type RabbitServer struct {
+type AMQPServer struct {
 	// this is the routing key prefix for all endpoints
 	ServiceName        string
 	ServiceDescription string
@@ -21,42 +21,42 @@ type RabbitServer struct {
 	connection         *rabbit.RabbitConnection
 }
 
-func NewRabbitServer() Server {
-	return &RabbitServer{
+func NewAMQPServer() Server {
+	return &AMQPServer{
 		endpointRegistry: NewEndpointRegistry(),
 		connection:       rabbit.NewRabbitConnection(),
 	}
 }
 
-func (s *RabbitServer) Name() string {
+func (s *AMQPServer) Name() string {
 	if s == nil {
 		return ""
 	}
 	return s.ServiceName
 }
 
-func (s *RabbitServer) Description() string {
+func (s *AMQPServer) Description() string {
 	if s == nil {
 		return ""
 	}
 	return s.ServiceDescription
 }
 
-func (s *RabbitServer) Initialise(c *Config) {
+func (s *AMQPServer) Initialise(c *Config) {
 	s.ServiceName = c.Name
 	s.ServiceDescription = c.Description
 }
 
-func (s *RabbitServer) RegisterEndpoint(endpoint Endpoint) {
+func (s *AMQPServer) RegisterEndpoint(endpoint Endpoint) {
 	s.endpointRegistry.Register(endpoint)
 }
 
-func (s *RabbitServer) DeregisterEndpoint(endpointName string) {
+func (s *AMQPServer) DeregisterEndpoint(endpointName string) {
 	s.endpointRegistry.Deregister(endpointName)
 }
 
 // Run the server, connecting to our transport and serving requests
-func (s *RabbitServer) Run() {
+func (s *AMQPServer) Run() {
 
 	// Connect to AMQP
 	select {
@@ -84,7 +84,7 @@ func (s *RabbitServer) Run() {
 	log.Flush()
 }
 
-func (s *RabbitServer) handleRequest(delivery amqp.Delivery) {
+func (s *AMQPServer) handleRequest(delivery amqp.Delivery) {
 
 	endpointName := strings.Replace(delivery.RoutingKey, fmt.Sprintf("%s.", s.ServiceName), "", -1)
 	endpoint := s.endpointRegistry.Get(endpointName)

--- a/server/rabbitmq.go
+++ b/server/rabbitmq.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	log "github.com/cihub/seelog"
-	"github.com/golang/protobuf/proto"
 	"github.com/streadway/amqp"
 
 	"github.com/b2aio/typhon/rabbit"
@@ -106,7 +105,7 @@ func (s *AMQPServer) handleRequest(delivery amqp.Delivery) {
 	}
 
 	// Marshal the response
-	body, err := proto.Marshal(rsp)
+	body, err := rsp.Encode()
 	if err != nil {
 		log.Errorf("[Server] Failed to marshal response")
 	}

--- a/server/rabbitmq.go
+++ b/server/rabbitmq.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -107,5 +108,19 @@ func (s *AMQPServer) handleRequest(delivery amqp.Delivery) {
 		Timestamp:     time.Now().UTC(),
 		Body:          body,
 	}
+	s.connection.Publish("", delivery.ReplyTo, msg)
+}
+
+// respondWithError to a delivery, with the provided error
+func (s *AMQPServer) respondWithError(delivery amqp.Delivery, err error) {
+
+	// Construct a return message with an error
+	msg := amqp.Publishing{
+		CorrelationId: delivery.CorrelationId,
+		Timestamp:     time.Now().UTC(),
+		Body:          []byte(err.Error()),
+	}
+
+	// Publish the error back to the client
 	s.connection.Publish("", delivery.ReplyTo, msg)
 }

--- a/server/rabbitmq.go
+++ b/server/rabbitmq.go
@@ -11,7 +11,7 @@ import (
 	"github.com/golang/protobuf/proto"
 	"github.com/streadway/amqp"
 
-	"github.com/vinceprignano/bunny/rabbit"
+	"github.com/b2aio/typhon/rabbit"
 )
 
 type AMQPServer struct {

--- a/server/rabbitmq.go
+++ b/server/rabbitmq.go
@@ -43,7 +43,7 @@ func (s *AMQPServer) Description() string {
 	return s.ServiceDescription
 }
 
-func (s *AMQPServer) Initialise(c *Config) {
+func (s *AMQPServer) Init(c *Config) {
 	s.ServiceName = c.Name
 	s.ServiceDescription = c.Description
 }

--- a/server/rabbitmq.go
+++ b/server/rabbitmq.go
@@ -91,6 +91,7 @@ func (s *AMQPServer) handleRequest(delivery amqp.Delivery) {
 	endpoint := s.endpointRegistry.Get(endpointName)
 	if endpoint == nil {
 		log.Error("[Server] Endpoint not found, cannot handle request")
+		s.respondWithError(delivery, errors.New("Endpoint not found"))
 		return
 	}
 	req := NewAMQPRequest(&delivery)

--- a/server/response.go
+++ b/server/response.go
@@ -1,6 +1,31 @@
 package server
 
+import "github.com/golang/protobuf/proto"
+
 // Response defines an interface that all handler responses must satisfy
 type Response interface {
 	Encode() ([]byte, error)
+}
+
+// Various Response type implementations
+
+// NewProtoResponse creates a new Response from a protobuf message
+func NewProtoResponse(p proto.Message) Response {
+	return &ProtoResponse{
+		pb: p,
+	}
+}
+
+// ProtoResponse represents a protobuf message used as a response
+type ProtoResponse struct {
+	pb proto.Message
+}
+
+// Encode the protobuf message to bytes for transmission
+func (p *ProtoResponse) Encode() ([]byte, error) {
+	if p == nil || p.pb == nil {
+		return []byte{}, nil
+	}
+
+	return proto.Marshal(p.pb)
 }

--- a/server/response.go
+++ b/server/response.go
@@ -1,0 +1,6 @@
+package server
+
+// Response defines an interface that all handler responses must satisfy
+type Response interface {
+	Encode() ([]byte, error)
+}

--- a/server/server.go
+++ b/server/server.go
@@ -3,7 +3,7 @@ package server
 // Server is an interface that all servers must implement
 // so that we can register endpoints, and serve requests
 type Server interface {
-	Initialise(*Config)
+	Init(*Config)
 	Run()
 
 	Name() string
@@ -16,9 +16,9 @@ type Server interface {
 // DefaultServer stores a default implementation, for simple usage
 var DefaultServer Server = NewAMQPServer()
 
-// Initialise our DefaultServer with a Config
-func Initialise(c *Config) {
-	DefaultServer.Initialise(c)
+// Init our DefaultServer with a Config
+func Init(c *Config) {
+	DefaultServer.Init(c)
 }
 
 // RegisterEndpoint with the DefaultServer

--- a/server/server.go
+++ b/server/server.go
@@ -11,7 +11,8 @@ type Server interface {
 	DeregisterEndpoint(pattern string)
 }
 
-var DefaultServer Server = NewRabbitServer()
+// DefaultServer stores a default implementation, for simple usage
+var DefaultServer Server = NewAMQPServer()
 
 // Initialise our DefaultServer with a Config
 func Initialise(c *Config) {

--- a/server/server.go
+++ b/server/server.go
@@ -1,5 +1,7 @@
 package server
 
+// Server is an interface that all servers must implement
+// so that we can register endpoints, and serve requests
 type Server interface {
 	Initialise(*Config)
 	Run()

--- a/test/mock.go
+++ b/test/mock.go
@@ -23,7 +23,7 @@ func NewBunnyTestServer(name string, description string) *BunnyTestServer {
 	return srv
 }
 
-func (b *BunnyTestServer) Initialise(s *server.Config) {
+func (b *BunnyTestServer) Init(s *server.Config) {
 	b.Called()
 }
 

--- a/test/mock.go
+++ b/test/mock.go
@@ -1,9 +1,9 @@
 package test
 
 import (
+	"github.com/b2aio/typhon/server"
 	"github.com/golang/protobuf/proto"
 	"github.com/stretchr/testify/mock"
-	"github.com/vinceprignano/bunny/server"
 )
 
 type BunnyTestServer struct {

--- a/test/test.go
+++ b/test/test.go
@@ -1,10 +1,10 @@
 package test
 
 import (
+	"github.com/b2aio/typhon/client"
+	"github.com/b2aio/typhon/server"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
-	"github.com/vinceprignano/bunny/client"
-	"github.com/vinceprignano/bunny/server"
 )
 
 type BunnyTest struct {


### PR DESCRIPTION
 - [x] Tweak example handler name to drop the 'handler': `func Hello(req server.Request) (server.Response, error)`
 - [x] `s/server.Initialise/server.Init` because s/z :wink: 
 - [x] `s/Rabbit/AMQP` in a few more places
 - [x] Publish an error back to the client on error, rather than not responding
 - [x] Updated imports in all packages to the new location.
 - [x] Change handler interface to return a `server.Response` interface which must implement an `Encode()` method