### PR TITLE
Separate test server, allow remote Close()

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -5,6 +5,7 @@ package server
 type Server interface {
 	Init(*Config)
 	Run()
+	Close()
 	NotifyConnected() chan bool
 
 	Name() string
@@ -30,6 +31,11 @@ func RegisterEndpoint(endpoint Endpoint) {
 // Run the DefaultServer
 func Run() {
 	DefaultServer.Run()
+}
+
+// Close the DefaultServer
+func Close() {
+	DefaultServer.Close()
 }
 
 // NotifyConnected delegates to DefaultServer

--- a/test/server.go
+++ b/test/server.go
@@ -1,0 +1,27 @@
+package test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/b2aio/typhon/server"
+)
+
+// InitServer for testing
+func InitServer(t *testing.T, name string) server.Server {
+	// Initialize our Server
+	server.Init(&server.Config{
+		Name:        name,
+		Description: "Example service",
+	})
+
+	go server.Run()
+
+	select {
+	case <-server.NotifyConnected():
+	case <-time.After(1 * time.Second):
+		t.Fatalf("StubServer couldn't connect to RabbitMQ")
+	}
+
+	return server.DefaultServer
+}

--- a/test/server.go
+++ b/test/server.go
@@ -20,7 +20,7 @@ func InitServer(t *testing.T, name string) server.Server {
 	select {
 	case <-server.NotifyConnected():
 	case <-time.After(1 * time.Second):
-		t.Fatalf("StubServer couldn't connect to RabbitMQ")
+		t.Fatalf("Test Server couldn't connect to RabbitMQ")
 	}
 
 	return server.DefaultServer

--- a/typhon_test.go
+++ b/typhon_test.go
@@ -2,39 +2,22 @@ package typhon
 
 import (
 	"testing"
-	"time"
 
 	"github.com/b2aio/typhon/client"
-	"github.com/b2aio/typhon/example/proto/callhello"
-	"github.com/b2aio/typhon/server"
-	"github.com/stretchr/testify/require"
-
 	"github.com/b2aio/typhon/example/handler"
+	"github.com/b2aio/typhon/example/proto/callhello"
+	"github.com/b2aio/typhon/test"
+	"github.com/stretchr/testify/require"
 )
-
-func initServer(t *testing.T) {
-	// Initialize our Server
-	server.Init(&server.Config{
-		Name:        "example",
-		Description: "Example service",
-	})
-
-	// Register an example endpoint
-	server.RegisterEndpoint(handler.Hello)
-	server.RegisterEndpoint(handler.CallHello)
-
-	go server.Run()
-
-	select {
-	case <-server.NotifyConnected():
-	case <-time.After(1 * time.Second):
-		t.Fatalf("StubServer couldn't connect to RabbitMQ")
-	}
-}
 
 func TestExample(t *testing.T) {
 
-	initServer(t)
+	s := test.InitServer(t, "example")
+	defer s.Close()
+
+	// Register example endpoints
+	s.RegisterEndpoint(handler.Hello)
+	s.RegisterEndpoint(handler.CallHello)
 
 	resp := &callhello.Response{}
 	client.Request(
@@ -47,5 +30,4 @@ func TestExample(t *testing.T) {
 	t.Logf("[testHandler] received %s", resp)
 	require.Equal(t, "example.hello says 'Hello, Bunny!'", resp.Value)
 	// Log the response we receive
-
 }


### PR DESCRIPTION
Allow `Close()` to be called on the server, terminating the AMQP connection, and shutting down the server listening loop.

Also move the test server to the test package, so we can reuse it from other packages