### PR TITLE
Fix typo and potential panics

### DIFF
--- a/client/rabbitmq.go
+++ b/client/rabbitmq.go
@@ -102,7 +102,6 @@ func (c *RabbitClient) Call(ctx context.Context, serviceName, endpoint string, r
 	}
 
 	replyChannel := c.inflight.push(correlation.String())
-	defer close(replyChannel)
 
 	requestBody, err := proto.Marshal(req)
 	if err != nil {

--- a/client/rabbitmq.go
+++ b/client/rabbitmq.go
@@ -126,7 +126,7 @@ func (c *RabbitClient) Call(ctx context.Context, serviceName, endpoint string, r
 	case delivery := <-replyChannel:
 		return handleResponse(delivery, resp)
 	case <-time.After(defaultTimeout):
-		e := fmt.Errorf("Timeout caling %v")
+		e := fmt.Errorf("Timeout calling %v", routingKey)
 		log.Warnf("[Client] %v", e)
 		return errors.Timeout(fmt.Sprintf("%s.timeout", routingKey), e.Error())
 	}


### PR DESCRIPTION
Writing to a closed channel results in a panic. This means if a client times out, and closes its reply channel, but a reply _was_ sent, receiving this causes a runtime panic.

By not closing the channel we allow a response to come back, and be written into the channel, at which point it will fall out of scope at both ends and the garbage collector will pick it up at some point.

Separately we should be manually collecting timed out responses from the inflight registry after a period of time - otherwise in the case we never receive a response the channel will never be garbage collected.