### PR TITLE
Fix various bugs including 100% cpu usage on connection close

### DIFF
--- a/client/rabbitmq.go
+++ b/client/rabbitmq.go
@@ -95,6 +95,11 @@ func (c *RabbitClient) Call(ctx context.Context, serviceName, endpoint string, r
 	// and if not, block for a short period of time while attempting to reconnect
 	c.once.Do(c.Init)
 
+	// Don't even try to send if not connected
+	if !c.connection.IsConnected() {
+		return errors.Wrap(fmt.Errorf("Not connected to AMQP"))
+	}
+
 	routingKey := c.buildRoutingKey(serviceName, endpoint)
 
 	correlation, err := uuid.NewV4()

--- a/client/rabbitmq.go
+++ b/client/rabbitmq.go
@@ -20,6 +20,8 @@ import (
 	"github.com/b2aio/typhon/rabbit"
 )
 
+var connectionTimeout time.Duration = 10 * time.Second
+
 type RabbitClient struct {
 	once       sync.Once
 	inflight   *inflightRegistry
@@ -44,8 +46,8 @@ func (c *RabbitClient) Init() {
 	select {
 	case <-c.connection.Init():
 		log.Info("[Client] Connected to RabbitMQ")
-	case <-time.After(10 * time.Second):
-		log.Critical("[Client] Failed to connect to RabbitMQ")
+	case <-time.After(connectionTimeout):
+		log.Critical("[Client] Failed to connect to RabbitMQ after %v", connectionTimeout)
 		os.Exit(1)
 	}
 	c.initConsume()

--- a/client/rabbitmq.go
+++ b/client/rabbitmq.go
@@ -56,14 +56,12 @@ func (c *RabbitClient) Init() {
 func (c *RabbitClient) initConsume() {
 	err := c.connection.Channel.DeclareReplyQueue(c.replyTo)
 	if err != nil {
-		log.Critical("[Client] Failed to declare reply queue")
-		log.Critical(err.Error())
+		log.Criticalf("[Client] Failed to declare reply queue: %s", err.Error())
 		os.Exit(1)
 	}
 	deliveries, err := c.connection.Channel.ConsumeQueue(c.replyTo)
 	if err != nil {
-		log.Critical("[Client] Failed to consume from reply queue")
-		log.Critical(err.Error())
+		log.Criticalf("[Client] Failed to consume from reply queue: %s", err.Error())
 		os.Exit(1)
 	}
 	go func() {
@@ -71,19 +69,21 @@ func (c *RabbitClient) initConsume() {
 		for delivery := range deliveries {
 			go c.handleDelivery(delivery)
 		}
+		log.Infof("[Client] Delivery channel %s closed", c.replyTo)
 	}()
 }
 
 func (c *RabbitClient) handleDelivery(delivery amqp.Delivery) {
 	channel := c.inflight.pop(delivery.CorrelationId)
 	if channel == nil {
-		log.Errorf("[Client] CorrelationID '%s' does not exist in inflight registry", delivery.CorrelationId)
+		log.Warnf("[Client] CorrelationID '%s' does not exist in inflight registry", delivery.CorrelationId)
 		return
 	}
 	select {
 	case channel <- delivery:
+		log.Tracef("[Client] Dispatched delivery to response channel for %s", delivery.CorrelationId)
 	default:
-		log.Errorf("[Client] Error in delivery for correlation %s", delivery.CorrelationId)
+		log.Warnf("[Client] Error in delivery for message %s", delivery.CorrelationId)
 	}
 }
 
@@ -103,6 +103,8 @@ func (c *RabbitClient) Call(ctx context.Context, serviceName, endpoint string, r
 		return errors.Wrap(err) // @todo custom error code
 	}
 
+	log.Debugf("[Client] Dispatching request to %s with correlation ID %s", routingKey, correlation.String())
+
 	replyChannel := c.inflight.push(correlation.String())
 
 	requestBody, err := proto.Marshal(req)
@@ -120,15 +122,16 @@ func (c *RabbitClient) Call(ctx context.Context, serviceName, endpoint string, r
 
 	err = c.connection.Publish(rabbit.Exchange, routingKey, message)
 	if err != nil {
-		log.Errorf("[Client] Failed to publish to '%s': %v", routingKey, err)
+		log.Errorf("[Client] Failed to publish %s to '%s': %v", correlation.String(), routingKey, err)
 		return errors.Wrap(err) // @todo custom error code
 	}
 
 	select {
 	case delivery := <-replyChannel:
+		log.Debugf("[Client] Response received for %s from %s", correlation.String(), routingKey)
 		return handleResponse(delivery, resp)
 	case <-time.After(defaultTimeout):
-		log.Errorf("%s timed out", routingKey)
+		log.Errorf("[Client] Request %s timed out calling %s", correlation.String(), routingKey)
 
 		return errors.Timeout(fmt.Sprintf("%s timed out", routingKey), nil, map[string]string{
 			"called_service":  serviceName,
@@ -167,7 +170,7 @@ func deliveryIsError(delivery amqp.Delivery) bool {
 	encoding, ok := delivery.Headers["Content-Encoding"].(string)
 	if !ok {
 		// Can't type assert header to string, assume error
-		log.Warnf("Service returned invalid Content-Encoding header %v", encoding)
+		log.Warnf("[Client] Service returned invalid Content-Encoding header %v", encoding)
 		return true
 	}
 

--- a/rabbit/channel.go
+++ b/rabbit/channel.go
@@ -54,26 +54,63 @@ func (r *RabbitChannel) Publish(exchange, routingKey string, message amqp.Publis
 }
 
 func (r *RabbitChannel) DeclareExchange(exchange string) error {
-	return r.channel.ExchangeDeclare(exchange, "topic", false, false, false, false, nil)
+	return r.channel.ExchangeDeclare(
+		exchange, // name
+		"topic",  // kind
+		false,    // durable
+		false,    // autoDelete
+		false,    // internal
+		false,    // noWait
+		nil,      // args
+	)
 }
 
 func (r *RabbitChannel) DeclareQueue(queue string) error {
-	_, err := r.channel.QueueDeclare(queue, false, true, false, false, nil)
+	_, err := r.channel.QueueDeclare(
+		queue, // name
+		false, // durable
+		true,  // autoDelete
+		false, // exclusive
+		false, // noWait
+		nil,   // args
+	)
 	return err
 }
 
 func (r *RabbitChannel) DeclareDurableQueue(queue string) error {
-	_, err := r.channel.QueueDeclare(queue, true, false, false, false, nil)
+	_, err := r.channel.QueueDeclare(
+		queue, // name
+		true,  // durable
+		false, // autoDelete
+		false, // exclusive
+		false, // noWait
+		nil,   // args
+	)
 	return err
 }
 
 func (r *RabbitChannel) DeclareReplyQueue(queue string) error {
-	_, err := r.channel.QueueDeclare(queue, false, true, true, false, nil)
+	_, err := r.channel.QueueDeclare(
+		queue, // name
+		false, // durable
+		true,  // autoDelete
+		true,  // exclusive
+		false, // noWait
+		nil,   // args
+	)
 	return err
 }
 
 func (r *RabbitChannel) ConsumeQueue(queue string) (<-chan amqp.Delivery, error) {
-	return r.channel.Consume(queue, r.uuid, false, false, false, false, nil)
+	return r.channel.Consume(
+		queue,  // queue
+		r.uuid, // consumer
+		false,  // autoAck
+		false,  // exclusive
+		false,  // nolocal
+		false,  // nowait
+		nil,    // args
+	)
 }
 
 func (r *RabbitChannel) BindQueue(queue, exchange string) error {

--- a/rabbit/channel.go
+++ b/rabbit/channel.go
@@ -105,7 +105,7 @@ func (r *RabbitChannel) ConsumeQueue(queue string) (<-chan amqp.Delivery, error)
 	return r.channel.Consume(
 		queue,  // queue
 		r.uuid, // consumer
-		false,  // autoAck
+		true,   // autoAck
 		false,  // exclusive
 		false,  // nolocal
 		false,  // nowait

--- a/rabbit/rabbit.go
+++ b/rabbit/rabbit.go
@@ -56,7 +56,9 @@ func (r *RabbitConnection) Init() chan bool {
 
 func (r *RabbitConnection) Connect(connected chan bool) {
 	for {
+		log.Debugf("[Rabbit] Attempting to connect")
 		if err := r.tryToConnect(); err != nil {
+			log.Debugf("[Rabbit] Failed to connect, sleeping 1s")
 			time.Sleep(1 * time.Second)
 			continue
 		}
@@ -67,12 +69,13 @@ func (r *RabbitConnection) Connect(connected chan bool) {
 
 		// Block until we get disconnected, or shut down
 		select {
-		case <-notifyClose:
+		case err := <-notifyClose:
 			// Spin around and reconnect
 			r.connected = false
 			log.Debugf("[Rabbit] AMQP connection closed (notifyClose): %s", err.Error())
 		case <-r.closeChan:
 			// Shut down connection
+			log.Debugf("[Rabbit] Closing AMQP connection (closeChan closed)")
 			if err := r.Connection.Close(); err != nil {
 				log.Errorf("Failed to close AMQP connection: %v", err)
 			}

--- a/rabbit/rabbit.go
+++ b/rabbit/rabbit.go
@@ -20,11 +20,13 @@ func init() {
 		RabbitURL = "amqp://localhost:5672"
 		log.Infof("Setting RABBIT_URL to default value %s", RabbitURL)
 	}
+	log.Infof("Set RABBIT_URL to %s", RabbitURL)
 	Exchange = os.Getenv("RABBIT_EXCHANGE")
 	if Exchange == "" {
 		Exchange = "typhon"
 		log.Infof("Setting RABBIT_EXCHANGE to default value %s", Exchange)
 	}
+	log.Infof("Set RABBIT_EXCHANGE to %s", Exchange)
 }
 
 func NewRabbitConnection() *RabbitConnection {
@@ -90,7 +92,7 @@ func (r *RabbitConnection) tryToConnect() error {
 	var err error
 	r.Connection, err = amqp.Dial(RabbitURL)
 	if err != nil {
-		log.Error("[Rabbit] Failed to establish connection with RabbitMQ")
+		log.Errorf("[Rabbit] Failed to establish connection with RabbitMQ: %s", RabbitURL)
 		return err
 	}
 	r.Channel, err = NewRabbitChannel(r.Connection)

--- a/server/amqp_request.go
+++ b/server/amqp_request.go
@@ -3,10 +3,11 @@ package server
 import (
 	"strings"
 
-	"github.com/b2aio/typhon/client"
 	"github.com/golang/protobuf/proto"
 	"github.com/streadway/amqp"
 	"golang.org/x/net/context"
+
+	"github.com/b2aio/typhon/client"
 )
 
 type AMQPRequest struct {

--- a/server/rabbitmq.go
+++ b/server/rabbitmq.go
@@ -2,7 +2,6 @@ package server
 
 import (
 	"fmt"
-	"os"
 	"strings"
 	"time"
 
@@ -118,6 +117,7 @@ func (s *AMQPServer) Close() {
 
 // handleRequest takes a delivery from AMQP, attempts to process it and return a response
 func (s *AMQPServer) handleRequest(delivery amqp.Delivery) {
+	log.Tracef("Handling Request (delivery): %s\n\n", delivery.RoutingKey)
 
 	// See if we have a matching endpoint for this request
 	endpointName := strings.Replace(delivery.RoutingKey, fmt.Sprintf("%s.", s.ServiceName), "", -1)
@@ -156,6 +156,8 @@ func (s *AMQPServer) handleRequest(delivery amqp.Delivery) {
 			"Content-Encoding": "RESPONSE",
 		},
 	}
+
+	log.Tracef("[Server] Sending response to %s", delivery.ReplyTo)
 	s.connection.Publish("", delivery.ReplyTo, msg)
 }
 
@@ -181,5 +183,6 @@ func (s *AMQPServer) respondWithError(delivery amqp.Delivery, err error) {
 	}
 
 	// Publish the error back to the client
+	log.Tracef("[Server] Sending error response to %s", delivery.ReplyTo)
 	s.connection.Publish("", delivery.ReplyTo, msg)
 }

--- a/server/rabbitmq.go
+++ b/server/rabbitmq.go
@@ -117,7 +117,7 @@ func (s *AMQPServer) Close() {
 
 // handleRequest takes a delivery from AMQP, attempts to process it and return a response
 func (s *AMQPServer) handleRequest(delivery amqp.Delivery) {
-	log.Tracef("Handling Request (delivery): %s\n\n", delivery.RoutingKey)
+	log.Tracef("Handling Request (delivery): %s", delivery.RoutingKey)
 
 	// See if we have a matching endpoint for this request
 	endpointName := strings.Replace(delivery.RoutingKey, fmt.Sprintf("%s.", s.ServiceName), "", -1)

--- a/server/rabbitmq.go
+++ b/server/rabbitmq.go
@@ -91,8 +91,12 @@ func (s *AMQPServer) Run() {
 	// Handle deliveries
 	for {
 		select {
-		case req := <-deliveries:
-			log.Infof("[Server] [%s] Received new delivery", s.ServiceName)
+		case req, ok := <-deliveries:
+			if !ok {
+				log.Infof("[Server] Delivery channel closed, exiting")
+				return
+			}
+			log.Tracef("[Server] Received new delivery: %#v", req)
 			go s.handleRequest(req)
 		case <-s.closeChan:
 			// shut down server

--- a/server/rabbitmq.go
+++ b/server/rabbitmq.go
@@ -14,6 +14,8 @@ import (
 	"github.com/b2aio/typhon/rabbit"
 )
 
+var connectionTimeout time.Duration = 10 * time.Second
+
 type AMQPServer struct {
 	// this is the routing key prefix for all endpoints
 	ServiceName        string
@@ -76,9 +78,9 @@ func (s *AMQPServer) Run() {
 		for _, notify := range s.notifyConnected {
 			notify <- true
 		}
-	case <-time.After(10 * time.Second):
-		log.Critical("[Server] Failed to connect to RabbitMQ")
-		os.Exit(1)
+	case <-time.After(connectionTimeout):
+		log.Critical("[Server] Failed to connect to RabbitMQ after %v", connectionTimeout)
+		return
 	}
 
 	// Get a delivery channel from the connection

--- a/test/helpers.go
+++ b/test/helpers.go
@@ -2,6 +2,7 @@ package test
 
 import (
 	"testing"
+	"time"
 
 	"github.com/b2aio/typhon/server"
 	"github.com/golang/protobuf/proto"
@@ -27,7 +28,9 @@ func CallEndpoint(t *testing.T, endpoint *server.Endpoint, reqProto proto.Messag
 	reqBytes, err := proto.Marshal(reqProto)
 	require.NoError(t, err)
 	resp, err := endpoint.HandleRequest(server.NewAMQPRequest(&amqp.Delivery{
-		Body: reqBytes,
+		// todo - add other params here
+		Timestamp: time.Now().UTC(),
+		Body:      reqBytes,
 	}))
 	if err != nil {
 		return err


### PR DESCRIPTION
 - [x] Fix infinite blank delivery bug when the AMQP connection closed - caused 100% cpu usage
 - [x] Add _much_ better logging. Some parts are verbose, but set at `trace` and `debug` levels
 - [x] Fix message delivery acknowledgement - we weren't ack'ing messages, we now auto ack
 - [x] Catch errors on connection, channel & queue declaration etc, and return them rather than swallowing them
 - [x] Fail immediately in the client if not connected