### PR TITLE
Refactoring to support RPC

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -9,7 +9,7 @@ import (
 
 type Client interface {
 	Init()
-	Call(ctx context.Context, service, endpoint string, req proto.Message, res proto.Message) error
+	Request(ctx context.Context, service, endpoint string, req proto.Message, res proto.Message) error
 }
 
 var defaultTimeout time.Duration = 1 * time.Second
@@ -18,5 +18,5 @@ var DefaultClient Client = NewRabbitClient()
 
 // Request sends a request to a service using the DefaultClient
 func Request(ctx context.Context, service, endpoint string, req proto.Message, res proto.Message) error {
-	return DefaultClient.Call(ctx, service, endpoint, req, res)
+	return DefaultClient.Request(ctx, service, endpoint, req, res)
 }

--- a/client/client.go
+++ b/client/client.go
@@ -10,6 +10,7 @@ import (
 type Client interface {
 	Init()
 	Req(ctx context.Context, service, endpoint string, req proto.Message, res proto.Message) error
+	CustomReq(req *Request) (*Response, error)
 }
 
 var defaultTimeout time.Duration = 1 * time.Second
@@ -20,4 +21,10 @@ var DefaultClient Client = NewRabbitClient()
 // and unmarshals the response into the supplied protobuf
 func Req(ctx context.Context, service, endpoint string, req proto.Message, res proto.Message) error {
 	return DefaultClient.Req(ctx, service, endpoint, req, res)
+}
+
+// CustomReq sends a raw request using the DefaultClient
+// without the usual marshaling helpers
+func CustomReq(req *Request) (*Response, error) {
+	return DefaultClient.CustomReq(req)
 }

--- a/client/client.go
+++ b/client/client.go
@@ -9,14 +9,15 @@ import (
 
 type Client interface {
 	Init()
-	Request(ctx context.Context, service, endpoint string, req proto.Message, res proto.Message) error
+	Req(ctx context.Context, service, endpoint string, req proto.Message, res proto.Message) error
 }
 
 var defaultTimeout time.Duration = 1 * time.Second
 
 var DefaultClient Client = NewRabbitClient()
 
-// Request sends a request to a service using the DefaultClient
-func Request(ctx context.Context, service, endpoint string, req proto.Message, res proto.Message) error {
-	return DefaultClient.Request(ctx, service, endpoint, req, res)
+// Req sends a request to a service using the DefaultClient
+// and unmarshals the response into the supplied protobuf
+func Req(ctx context.Context, service, endpoint string, req proto.Message, res proto.Message) error {
+	return DefaultClient.Req(ctx, service, endpoint, req, res)
 }

--- a/client/client.go
+++ b/client/client.go
@@ -10,7 +10,7 @@ import (
 type Client interface {
 	Init()
 	Req(ctx context.Context, service, endpoint string, req proto.Message, res proto.Message) error
-	CustomReq(req *Request) (Response, error)
+	CustomReq(req Request) (Response, error)
 }
 
 var defaultTimeout time.Duration = 1 * time.Second
@@ -25,6 +25,6 @@ func Req(ctx context.Context, service, endpoint string, req proto.Message, res p
 
 // CustomReq sends a raw request using the DefaultClient
 // without the usual marshaling helpers
-func CustomReq(req *Request) (Response, error) {
+func CustomReq(req Request) (Response, error) {
 	return DefaultClient.CustomReq(req)
 }

--- a/client/client.go
+++ b/client/client.go
@@ -10,7 +10,7 @@ import (
 type Client interface {
 	Init()
 	Req(ctx context.Context, service, endpoint string, req proto.Message, res proto.Message) error
-	CustomReq(req *Request) (*Response, error)
+	CustomReq(req *Request) (Response, error)
 }
 
 var defaultTimeout time.Duration = 1 * time.Second
@@ -25,6 +25,6 @@ func Req(ctx context.Context, service, endpoint string, req proto.Message, res p
 
 // CustomReq sends a raw request using the DefaultClient
 // without the usual marshaling helpers
-func CustomReq(req *Request) (*Response, error) {
+func CustomReq(req *Request) (Response, error) {
 	return DefaultClient.CustomReq(req)
 }

--- a/client/rabbitmq.go
+++ b/client/rabbitmq.go
@@ -87,7 +87,7 @@ func (c *RabbitClient) handleDelivery(delivery amqp.Delivery) {
 	}
 }
 
-func (c *RabbitClient) Request(ctx context.Context, serviceName, endpoint string, req proto.Message, resp proto.Message) error {
+func (c *RabbitClient) Req(ctx context.Context, serviceName, endpoint string, req proto.Message, resp proto.Message) error {
 
 	// Ensure we're initialised, but only do this once
 	//

--- a/client/rabbitmq.go
+++ b/client/rabbitmq.go
@@ -87,7 +87,7 @@ func (c *RabbitClient) handleDelivery(delivery amqp.Delivery) {
 	}
 }
 
-func (c *RabbitClient) Call(ctx context.Context, serviceName, endpoint string, req proto.Message, resp proto.Message) error {
+func (c *RabbitClient) Request(ctx context.Context, serviceName, endpoint string, req proto.Message, resp proto.Message) error {
 
 	// Ensure we're initialised, but only do this once
 	//

--- a/client/rabbitmq.go
+++ b/client/rabbitmq.go
@@ -155,9 +155,15 @@ func (c *RabbitClient) do(req Request) (Response, error) {
 		},
 	}
 
+	// Attempt to publish through our connection
+	// @todo refactor this to not know about rabbitmq internals
 	err := c.connection.Publish(rabbit.Exchange, routingKey, message)
 	if err != nil {
 		log.Errorf("[Client] Failed to publish %s to '%s': %v", req.Id(), routingKey, err)
+
+		// Remove from inflight requests
+		_ = c.inflight.pop(req.Id())
+
 		return nil, errors.Wrap(err) // @todo custom error code
 	}
 

--- a/client/rabbitmq.go
+++ b/client/rabbitmq.go
@@ -183,7 +183,7 @@ func deliveryIsError(delivery amqp.Delivery) bool {
 		return true
 	}
 
-	if encoding == "" || encoding == "ERROR" {
+	if encoding == "" || encoding == "error" {
 		return true
 	}
 

--- a/client/rabbitmq.go
+++ b/client/rabbitmq.go
@@ -145,6 +145,10 @@ func (c *RabbitClient) Req(ctx context.Context, serviceName, endpoint string, re
 	}
 }
 
+func (c *RabbitClient) CustomReq(req *Request) (*Response, error) {
+	return fmt.Errorf("not implemented")
+}
+
 func (c *RabbitClient) buildRoutingKey(serviceName, endpoint string) string {
 	return fmt.Sprintf("%s.%s", serviceName, endpoint)
 }

--- a/client/rabbitmq.go
+++ b/client/rabbitmq.go
@@ -212,7 +212,7 @@ func deliveryToResponse(delivery amqp.Delivery) Response {
 }
 
 // unmarshalErrorResponse from our wire format to a typhon error
-func unmarshalErrorResponse(resp Response) *errors.Error {
+func unmarshalErrorResponse(resp Response) error {
 	p := &pe.Error{}
 	if err := proto.Unmarshal(resp.Payload(), p); err != nil {
 		return errors.BadResponse(err.Error())

--- a/client/rabbitmq.go
+++ b/client/rabbitmq.go
@@ -145,8 +145,8 @@ func (c *RabbitClient) Req(ctx context.Context, serviceName, endpoint string, re
 	}
 }
 
-func (c *RabbitClient) CustomReq(req *Request) (*Response, error) {
-	return fmt.Errorf("not implemented")
+func (c *RabbitClient) CustomReq(req *Request) (Response, error) {
+	return nil, fmt.Errorf("not implemented")
 }
 
 func (c *RabbitClient) buildRoutingKey(serviceName, endpoint string) string {

--- a/client/rabbitmq.go
+++ b/client/rabbitmq.go
@@ -137,7 +137,7 @@ func (c *RabbitClient) do(req Request) (Response, error) {
 
 	replyChannel := c.inflight.push(req.Id())
 
-	routingKey := c.buildRoutingKey(req.Service(), req.Endpoint())
+	routingKey := buildRoutingKey(req.Service(), req.Endpoint())
 	log.Debugf("[Client] Dispatching request to %s with correlation ID %s", routingKey, req.Id())
 
 	// Build message from request
@@ -174,7 +174,7 @@ func (c *RabbitClient) do(req Request) (Response, error) {
 }
 
 // buildRoutingKey to send the request via AMQP
-func (c *RabbitClient) buildRoutingKey(serviceName, endpoint string) string {
+func buildRoutingKey(serviceName, endpoint string) string {
 	return fmt.Sprintf("%s.%s", serviceName, endpoint)
 }
 

--- a/client/rabbitmq.go
+++ b/client/rabbitmq.go
@@ -113,13 +113,13 @@ func (c *RabbitClient) Req(ctx context.Context, service, endpoint string, req pr
 
 // CustomReq makes a sends a request to a service and returns a
 // response without the usual marshaling helpers
-func (c *RabbitClient) CustomReq(req *Request) (Response, error) {
+func (c *RabbitClient) CustomReq(req Request) (Response, error) {
 	return c.do(req)
 }
 
 // do sends a request and returns a response, following policies
 // (e.g. redirects, cookies, auth) as configured on the client.
-func (c *RabbitClient) do(req *Request) (Response, error) {
+func (c *RabbitClient) do(req Request) (Response, error) {
 
 	// Ensure we're initialised, but only do this once
 	//

--- a/client/rabbitmq.go
+++ b/client/rabbitmq.go
@@ -16,8 +16,9 @@ import (
 	"golang.org/x/net/context"
 
 	"github.com/b2aio/typhon/errors"
-	pe "github.com/b2aio/typhon/proto/error"
 	"github.com/b2aio/typhon/rabbit"
+
+	pe "github.com/b2aio/typhon/proto/error"
 )
 
 var connectionTimeout time.Duration = 10 * time.Second
@@ -146,6 +147,12 @@ func (c *RabbitClient) do(req Request) (Response, error) {
 		Timestamp:     time.Now().UTC(),
 		Body:          req.Payload(),
 		ReplyTo:       c.replyTo,
+		Headers: amqp.Table{
+			"Content-Type":     req.ContentType(),
+			"Content-Encoding": "request",
+			"Service":          req.Service(),
+			"Endpoint":         req.Endpoint(),
+		},
 	}
 
 	err := c.connection.Publish(rabbit.Exchange, routingKey, message)

--- a/client/request.go
+++ b/client/request.go
@@ -1,0 +1,32 @@
+package client
+
+type Request struct {
+	// contentType of the payload
+	contentType string
+	// service to be delivered to
+	service string
+	// endpoint to be delivered to at the service
+	endpoint string
+	// payload stores our raw payload to send
+	payload []byte
+}
+
+// NewProtoRequest creates a new request with protobuf encoding
+func NewProtoRequest(service, endpoint string, payload []byte) *Request {
+	return &Request{
+		contentType: "application/x-protobuf",
+		service:     service,
+		endpoint:    endpoint,
+		payload:     payload,
+	}
+}
+
+// NewJsonRequest creates a new request with json encoding
+func NewJsonRequest(service, endpoint string, payload []byte) *Request {
+	return &Request{
+		contentType: "application/json",
+		service:     service,
+		endpoint:    endpoint,
+		payload:     payload,
+	}
+}

--- a/client/request.go
+++ b/client/request.go
@@ -1,6 +1,15 @@
 package client
 
+import (
+	log "github.com/cihub/seelog"
+	"github.com/nu7hatch/gouuid"
+
+	"github.com/b2aio/typhon/errors"
+)
+
 type Request interface {
+	// Id of this request
+	Id() string
 	// ContentType of the payload
 	ContentType() string
 	// Service to be delivered to
@@ -12,6 +21,8 @@ type Request interface {
 }
 
 type request struct {
+	// id of this request
+	id string
 	// contentType of the payload
 	contentType string
 	// service to be delivered to
@@ -20,6 +31,11 @@ type request struct {
 	endpoint string
 	// payload stores our raw payload to send
 	payload []byte
+}
+
+// Id of the request
+func (r *request) Id() string {
+	return r.id
 }
 
 // ContentType of the request
@@ -43,21 +59,35 @@ func (r *request) Payload() []byte {
 }
 
 // NewProtoRequest creates a new request with protobuf encoding
-func NewProtoRequest(service, endpoint string, payload []byte) Request {
+func NewProtoRequest(service, endpoint string, payload []byte) (Request, error) {
+	requestId, err := uuid.NewV4()
+	if err != nil {
+		log.Errorf("[Client] Failed to create unique request id: %v", err)
+		return nil, errors.Wrap(err) // @todo custom error code
+	}
+
 	return &request{
+		id:          requestId.String(),
 		contentType: "application/x-protobuf",
 		service:     service,
 		endpoint:    endpoint,
 		payload:     payload,
-	}
+	}, nil
 }
 
 // NewJsonRequest creates a new request with json encoding
-func NewJsonRequest(service, endpoint string, payload []byte) Request {
+func NewJsonRequest(service, endpoint string, payload []byte) (Request, error) {
+	requestId, err := uuid.NewV4()
+	if err != nil {
+		log.Errorf("[Client] Failed to create unique request id: %v", err)
+		return nil, errors.Wrap(err) // @todo custom error code
+	}
+
 	return &request{
+		id:          requestId.String(),
 		contentType: "application/json",
 		service:     service,
 		endpoint:    endpoint,
 		payload:     payload,
-	}
+	}, nil
 }

--- a/client/request.go
+++ b/client/request.go
@@ -1,6 +1,17 @@
 package client
 
-type Request struct {
+type Request interface {
+	// ContentType of the payload
+	ContentType() string
+	// Service to be delivered to
+	Service() string
+	// Endpoint to be delivered to at the service
+	Endpoint() string
+	// Payload stores our raw payload to send
+	Payload() []byte
+}
+
+type request struct {
 	// contentType of the payload
 	contentType string
 	// service to be delivered to
@@ -12,28 +23,28 @@ type Request struct {
 }
 
 // ContentType of the request
-func (r *Request) ContentType() string {
+func (r *request) ContentType() string {
 	return r.contentType
 }
 
 // Service to be delivered to
-func (r *Request) Service() string {
+func (r *request) Service() string {
 	return r.service
 }
 
 // Endpoint to be delivered to at the service
-func (r *Request) Endpoint() string {
+func (r *request) Endpoint() string {
 	return r.endpoint
 }
 
 // Payload of the request
-func (r *Request) Payload() []byte {
+func (r *request) Payload() []byte {
 	return r.payload
 }
 
 // NewProtoRequest creates a new request with protobuf encoding
-func NewProtoRequest(service, endpoint string, payload []byte) *Request {
-	return &Request{
+func NewProtoRequest(service, endpoint string, payload []byte) Request {
+	return &request{
 		contentType: "application/x-protobuf",
 		service:     service,
 		endpoint:    endpoint,
@@ -42,8 +53,8 @@ func NewProtoRequest(service, endpoint string, payload []byte) *Request {
 }
 
 // NewJsonRequest creates a new request with json encoding
-func NewJsonRequest(service, endpoint string, payload []byte) *Request {
-	return &Request{
+func NewJsonRequest(service, endpoint string, payload []byte) Request {
+	return &request{
 		contentType: "application/json",
 		service:     service,
 		endpoint:    endpoint,

--- a/client/request.go
+++ b/client/request.go
@@ -11,6 +11,26 @@ type Request struct {
 	payload []byte
 }
 
+// ContentType of the request
+func (r *Request) ContentType() string {
+	return r.contentType
+}
+
+// Service to be delivered to
+func (r *Request) Service() string {
+	return r.service
+}
+
+// Endpoint to be delivered to at the service
+func (r *Request) Endpoint() string {
+	return r.endpoint
+}
+
+// Payload of the request
+func (r *Request) Payload() []byte {
+	return r.payload
+}
+
 // NewProtoRequest creates a new request with protobuf encoding
 func NewProtoRequest(service, endpoint string, payload []byte) *Request {
 	return &Request{

--- a/client/response.go
+++ b/client/response.go
@@ -35,5 +35,5 @@ func (r *Response) Payload() []byte {
 }
 
 func (r *Response) IsError() bool {
-	return contentEncoding == "ERROR"
+	return contentEncoding == "error"
 }

--- a/client/response.go
+++ b/client/response.go
@@ -1,6 +1,25 @@
 package client
 
-type Response struct {
+// Response represents a response from a service following an RPC call
+type Response interface {
+	// ContentType of the payload
+	ContentType() string
+	// Service the response is from
+	Service() string
+	// Endpoint the response is from
+	Endpoint() string
+	// Payload stores our raw response
+	Payload() []byte
+	// Is the response an Error
+	IsError() bool
+}
+
+// response is our concrete implementation
+//
+// @todo push creation of this down into the transport layer
+// and just use the interface within the client package
+// so that the client has no knowledge of the internals of the transport
+type response struct {
 	// contentType of the payload
 	contentType string
 	// contentEncoding is the encoding format of the returned response
@@ -15,25 +34,26 @@ type Response struct {
 }
 
 // ContentType of the response
-func (r *Response) ContentType() string {
+func (r *response) ContentType() string {
 	return r.contentType
 }
 
 // Service the response came from
-func (r *Response) Service() string {
+func (r *response) Service() string {
 	return r.service
 }
 
 // Endpoint the response came from
-func (r *Response) Endpoint() string {
+func (r *response) Endpoint() string {
 	return r.endpoint
 }
 
 // Payload of the response
-func (r *Response) Payload() []byte {
+func (r *response) Payload() []byte {
 	return r.payload
 }
 
-func (r *Response) IsError() bool {
-	return contentEncoding == "error"
+// IsError determines if the response is an error
+func (r *response) IsError() bool {
+	return r.contentEncoding == "error"
 }

--- a/client/response.go
+++ b/client/response.go
@@ -1,0 +1,39 @@
+package client
+
+type Response struct {
+	// contentType of the payload
+	contentType string
+	// contentEncoding is the encoding format of the returned response
+	// eg. a response, or an encoded error
+	contentEncoding string
+	// service the response is from
+	service string
+	// endpoint the response is from
+	endpoint string
+	// payload stores our raw response
+	payload []byte
+}
+
+// ContentType of the response
+func (r *Response) ContentType() string {
+	return r.contentType
+}
+
+// Service the response came from
+func (r *Response) Service() string {
+	return r.service
+}
+
+// Endpoint the response came from
+func (r *Response) Endpoint() string {
+	return r.endpoint
+}
+
+// Payload of the response
+func (r *Response) Payload() []byte {
+	return r.payload
+}
+
+func (r *Response) IsError() bool {
+	return contentEncoding == "ERROR"
+}

--- a/server/amqp_request.go
+++ b/server/amqp_request.go
@@ -80,5 +80,5 @@ func (r *AMQPRequest) ScopedRequest(service string, endpoint string, req proto.M
 	// This means we can nail down our external interface, and work the internals out properly
 	// where we can initialise a 'client' and separate out the connected transport layer
 	// a client in this case would allow multiple parallel requests etc.
-	return client.Request(r, service, endpoint, req, resp)
+	return client.Req(r, service, endpoint, req, resp)
 }

--- a/server/amqp_request.go
+++ b/server/amqp_request.go
@@ -1,8 +1,6 @@
 package server
 
 import (
-	"strings"
-
 	"github.com/golang/protobuf/proto"
 	"github.com/streadway/amqp"
 	"golang.org/x/net/context"
@@ -47,21 +45,11 @@ func (r *AMQPRequest) Id() string {
 }
 
 func (r *AMQPRequest) Service() string {
-	routingKey := r.RoutingKey()
-	lastDotIndex := strings.LastIndex(routingKey, ".")
-	if lastDotIndex == -1 {
-		return routingKey
-	}
-	return routingKey[:lastDotIndex]
+	return r.service
 }
 
 func (r *AMQPRequest) Endpoint() string {
-	routingKey := r.RoutingKey()
-	lastDotIndex := strings.LastIndex(routingKey, ".")
-	if lastDotIndex == -1 {
-		return ""
-	}
-	return routingKey[lastDotIndex+1:]
+	return r.endpoint
 }
 
 func (r *AMQPRequest) Payload() []byte {
@@ -77,7 +65,7 @@ func (r *AMQPRequest) SetBody(body interface{}) {
 }
 
 func (r *AMQPRequest) CorrelationID() string {
-	return r.delivery.CorrelationId
+	return r.id
 }
 
 func (r *AMQPRequest) ReplyTo() string {

--- a/server/amqp_request.go
+++ b/server/amqp_request.go
@@ -44,6 +44,14 @@ func (r *AMQPRequest) Id() string {
 	return r.id
 }
 
+func (r *AMQPRequest) ContentType() string {
+	return r.contentType
+}
+
+func (r *AMQPRequest) ContentEncoding() string {
+	return r.contentEncoding
+}
+
 func (r *AMQPRequest) Service() string {
 	return r.service
 }

--- a/server/amqp_request.go
+++ b/server/amqp_request.go
@@ -14,15 +14,37 @@ type AMQPRequest struct {
 	context.Context
 	body     interface{}
 	delivery *amqp.Delivery
+
+	id              string
+	contentType     string
+	contentEncoding string
+	service         string
+	endpoint        string
 }
 
 func NewAMQPRequest(delivery *amqp.Delivery) *AMQPRequest {
+
+	contentType, _ := delivery.Headers["Content-Type"].(string)
+	contentEncoding, _ := delivery.Headers["Content-Encoding"].(string)
+	service, _ := delivery.Headers["Service"].(string)
+	endpoint, _ := delivery.Headers["Endpoint"].(string)
+
 	return &AMQPRequest{
 		delivery: delivery,
+
+		id:              delivery.CorrelationId,
+		contentType:     contentType,
+		contentEncoding: contentEncoding,
+		service:         service,
+		endpoint:        endpoint,
 	}
 }
 
 // RabbitMQ / AMQP fields
+
+func (r *AMQPRequest) Id() string {
+	return r.id
+}
 
 func (r *AMQPRequest) Service() string {
 	routingKey := r.RoutingKey()

--- a/server/rabbitmq.go
+++ b/server/rabbitmq.go
@@ -153,6 +153,7 @@ func (s *AMQPServer) handleRequest(delivery amqp.Delivery) {
 		Timestamp:     time.Now().UTC(),
 		Body:          body,
 		Headers: map[string]interface{}{
+			"Content-Type":     "application/x-protobuf",
 			"Content-Encoding": "RESPONSE",
 		},
 	}
@@ -178,6 +179,7 @@ func (s *AMQPServer) respondWithError(delivery amqp.Delivery, err error) {
 		Timestamp:     time.Now().UTC(),
 		Body:          b,
 		Headers: map[string]interface{}{
+			"Content-Type":     "application/x-protobuf",
 			"Content-Encoding": "ERROR",
 		},
 	}

--- a/server/rabbitmq.go
+++ b/server/rabbitmq.go
@@ -154,7 +154,7 @@ func (s *AMQPServer) handleRequest(delivery amqp.Delivery) {
 		Body:          body,
 		Headers: map[string]interface{}{
 			"Content-Type":     "application/x-protobuf",
-			"Content-Encoding": "RESPONSE",
+			"Content-Encoding": "response",
 		},
 	}
 
@@ -180,7 +180,7 @@ func (s *AMQPServer) respondWithError(delivery amqp.Delivery, err error) {
 		Body:          b,
 		Headers: map[string]interface{}{
 			"Content-Type":     "application/x-protobuf",
-			"Content-Encoding": "ERROR",
+			"Content-Encoding": "error",
 		},
 	}
 

--- a/server/rabbitmq.go
+++ b/server/rabbitmq.go
@@ -155,6 +155,8 @@ func (s *AMQPServer) handleRequest(delivery amqp.Delivery) {
 		Headers: map[string]interface{}{
 			"Content-Type":     "application/x-protobuf",
 			"Content-Encoding": "response",
+			"Service":          s.ServiceName,
+			"Endpoint":         endpointName,
 		},
 	}
 

--- a/server/rabbitmq.go
+++ b/server/rabbitmq.go
@@ -133,6 +133,7 @@ func (s *AMQPServer) handleDelivery(delivery amqp.Delivery) {
 	// Handle the delivery
 	resp, err := endpoint.HandleRequest(req)
 	if err != nil {
+		log.Warnf("[Server] Failed to handle request: %s", err.Error())
 		s.respondWithError(delivery, err)
 		return
 	}

--- a/server/rabbitmq.go
+++ b/server/rabbitmq.go
@@ -188,7 +188,7 @@ func (s *AMQPServer) respondWithError(delivery amqp.Delivery, err error) {
 		CorrelationId: delivery.CorrelationId,
 		Timestamp:     time.Now().UTC(),
 		Body:          b,
-		Headers: map[string]interface{}{
+		Headers: amqp.Table{
 			"Content-Type":     "application/x-protobuf",
 			"Content-Encoding": "error",
 		},

--- a/server/rabbitmq.go
+++ b/server/rabbitmq.go
@@ -150,7 +150,7 @@ func (s *AMQPServer) handleDelivery(delivery amqp.Delivery) {
 		body, err = json.Marshal(resp)
 	}
 	if err != nil {
-		log.Errorf("[Server] Failed to marshal response")
+		log.Errorf("[Server] Failed to marshal response: %s", err.Error())
 		s.respondWithError(delivery, errors.BadResponse("Failed to marshal response: "+err.Error()))
 		return
 	}

--- a/server/request.go
+++ b/server/request.go
@@ -8,18 +8,21 @@ import (
 type Request interface {
 	context.Context
 
-	// Payload are the actual bytes returned from the transport
+	// Id of this message, used to correlate the response
+	Id() string
+	// ContentType of the payload
+	ContentType() string
+	// Payload of raw bytes received from the transport
 	Payload() []byte
-
 	// Body is the Unmarshalled `Payload()`. If `RequestType()` is set on
 	// the `Endpoint`, we can attempt to unmarshal it for you
 	Body() interface{}
+	// SetBody of this request
 	SetBody(interface{})
-
-	// Details about the service and endpoint being called
+	// Service which this request was intended for
 	Service() string
+	// Endpoint to be called on the receiving service
 	Endpoint() string
-
 	// ScopedRequest makes a client request within the scope of the current request
 	// @todo change the request & response interface to decouple from protobuf
 	ScopedRequest(service string, endpoint string, req proto.Message, resp proto.Message) error

--- a/test/error_passing_test.go
+++ b/test/error_passing_test.go
@@ -43,7 +43,7 @@ func TestErrorPropagation(t *testing.T) {
 
 	// call the service
 	resp := &callhello.Response{}
-	err := client.Request(
+	err := client.Req(
 		nil,                                // context
 		"test",                             // service
 		"callerror",                        // service endpoint to call

--- a/test/helpers.go
+++ b/test/helpers.go
@@ -31,6 +31,10 @@ func CallEndpoint(t *testing.T, endpoint *server.Endpoint, reqProto proto.Messag
 		// todo - add other params here
 		Timestamp: time.Now().UTC(),
 		Body:      reqBytes,
+		Headers: amqp.Table{
+			"Content-Type":     "application/x-protobuf",
+			"Content-Encoding": "request",
+		},
 	}))
 	if err != nil {
 		return err

--- a/typhon_test.go
+++ b/typhon_test.go
@@ -20,7 +20,7 @@ func TestExample(t *testing.T) {
 	s.RegisterEndpoint(handler.CallHello)
 
 	resp := &callhello.Response{}
-	client.Request(
+	client.Req(
 		nil,                                // context
 		"example",                          // service
 		"callhello",                        // service endpoint to call


### PR DESCRIPTION
Refactoring to make the interfaces a little more generic, and support raw requests in multiple encodings - allowing us to support JSON on the wire between services, and therefore push raw JSON requests in from an API.

## Client
 - [x] Add `client.Request` and `client.Response` interfaces, with concrete implementations
 - [x] Change `Call` func to `Req` (can't be called `Request` as it conflicts with the interface above)
 - [x] Add `CustomReq` which takes a raw `Request` and returns a `Response`
 - [x] Refactor underlying client request code into a generalised `do` method. This is less specific to AMQP, but still has some mentions of it
 - [x] Pass additional headers through rabbitmq to the server, including the content type (proto/json) of the message
 - [x] ~~Push AMQP client details down into the `rabbit` package~~
 - [x] ~~Move response type down into `rabbit` pkg, leaving interface in `client` pkg, and unmarshal there~~

## Server
 - [x] Unmarshal additional headers from client
 - [x] Use `Content-Type` header to determine unmarshaling func, now supports both proto and json
 - [x] Simplify service and endpoint identification by using delivery headers
 - [x] Marshal response back to client in the content-type they sent
 - [x] ~~Tidy up responding with a response interface / type~~

