### PR TITLE
Update inter-service routing

### DIFF
--- a/client/rabbitmq.go
+++ b/client/rabbitmq.go
@@ -139,7 +139,7 @@ func (c *RabbitClient) do(req Request) (Response, error) {
 	replyChannel := c.inflight.push(req.Id())
 
 	routingKey := buildRoutingKey(req.Service(), req.Endpoint())
-	log.Debugf("[Client] Dispatching request to %s with correlation ID %s", routingKey, req.Id())
+	log.Debugf("[Client] Dispatching request to %s with correlation ID %s, reply to %s", routingKey, req.Id(), c.replyTo)
 
 	// Build message from request
 	message := amqp.Publishing{

--- a/client/rabbitmq.go
+++ b/client/rabbitmq.go
@@ -138,7 +138,7 @@ func (c *RabbitClient) do(req Request) (Response, error) {
 
 	replyChannel := c.inflight.push(req.Id())
 
-	routingKey := buildRoutingKey(req.Service(), req.Endpoint())
+	routingKey := req.Service()
 	log.Debugf("[Client] Dispatching request to %s with correlation ID %s, reply to %s", routingKey, req.Id(), c.replyTo)
 
 	// Build message from request
@@ -184,11 +184,6 @@ func (c *RabbitClient) do(req Request) (Response, error) {
 		})
 	}
 
-}
-
-// buildRoutingKey to send the request via AMQP
-func buildRoutingKey(serviceName, endpoint string) string {
-	return fmt.Sprintf("%s.%s", serviceName, endpoint)
 }
 
 // unmarshalResponse returned from a service into the response type

--- a/rabbit/channel.go
+++ b/rabbit/channel.go
@@ -2,7 +2,6 @@ package rabbit
 
 import (
 	"errors"
-	"fmt"
 
 	"github.com/nu7hatch/gouuid"
 	"github.com/streadway/amqp"
@@ -114,5 +113,11 @@ func (r *RabbitChannel) ConsumeQueue(queue string) (<-chan amqp.Delivery, error)
 }
 
 func (r *RabbitChannel) BindQueue(queue, exchange string) error {
-	return r.channel.QueueBind(queue, fmt.Sprintf("%s.#", queue), exchange, false, nil)
+	return r.channel.QueueBind(
+		queue,    // name
+		queue,    // key
+		exchange, // exchange
+		false,    // noWait
+		nil,      // args
+	)
 }


### PR DESCRIPTION
Change routing & binding on rabbitmq to send message just to the service's name, and bind with just the service name, rather than also specifying the endpoint in the routing key and binding on a wildcard. 

Bind on `service.thing` rather than `service.thing.#`
Send to `service.thing` rather than `service.thing.someendpoint`

This makes routing easier to reason about, and simpler, as we don't bind per endpoint anyway; and the `server` package deals with invalid endpoints anway.