### PR TITLE
Move service name to the stub server, rather than endpoints

### DIFF
--- a/test/helpers.go
+++ b/test/helpers.go
@@ -12,9 +12,9 @@ import (
 
 var stubServer *StubServer
 
-func InitStubServer(t *testing.T) *StubServer {
+func InitStubServer(t *testing.T, serviceName string) *StubServer {
 	if stubServer == nil {
-		stubServer = NewStubServer(t)
+		stubServer = NewStubServer(t, serviceName)
 	}
 	return stubServer
 }


### PR DESCRIPTION
Currently the stub server binds on a wildcard routing key, which means this can conflict with other 'real' services bound on the same exchange (useful in more complex tests). This changes the stub server to only support a single service per instance, though multiple instances can be created, with the service name provided on creation. Multiple endpoints for that service can then be registered & stubbed.
