### PR TITLE
Fix panic

### DIFF
--- a/errors/marshaling.go
+++ b/errors/marshaling.go
@@ -31,11 +31,20 @@ func Unmarshal(p *pe.Error) *Error {
 			Message: "Nil error unmarshalled!",
 		}
 	}
+	// empty map[string]string come out as nil. thanks proto.
+	publicContext := p.PublicContext
+	if publicContext == nil {
+		publicContext = map[string]string{}
+	}
+	privateContext := p.PrivateContext
+	if privateContext == nil {
+		privateContext = map[string]string{}
+	}
 	return &Error{
 		Code:           int(p.Code),
 		Message:        p.Message,
-		PublicContext:  p.PublicContext,
-		PrivateContext: p.PrivateContext,
+		PublicContext:  publicContext,
+		PrivateContext: privateContext,
 		Stack:          protoToStack(p.Stack),
 	}
 }

--- a/errors/marshaling_test.go
+++ b/errors/marshaling_test.go
@@ -26,9 +26,9 @@ func TestUnmarshalNilError(t *testing.T) {
 	assert.Equal(t, "Nil error unmarshalled!", platError.Message)
 }
 
-// interchangingErrorTestCases represents a set of error formats
-// which should be converted between
-var interchangableErrorTestCases = []struct {
+// marshalTestCases represents a set of error formats
+// which should be marshaled
+var marshalTestCases = []struct {
 	platErr  *Error
 	protoErr *pe.Error
 }{
@@ -104,7 +104,7 @@ var interchangableErrorTestCases = []struct {
 }
 
 func TestMarshal(t *testing.T) {
-	for _, tc := range interchangableErrorTestCases {
+	for _, tc := range marshalTestCases {
 		protoError := Marshal(tc.platErr)
 		assert.Equal(t, tc.protoErr.Code, protoError.Code)
 		assert.Equal(t, tc.protoErr.Message, protoError.Message)
@@ -113,8 +113,90 @@ func TestMarshal(t *testing.T) {
 	}
 }
 
+// these are separate from above because the marshaling and unmarshaling isn'y symmetric.
+// protobuf turns empty maps[string]string into nil :(
+var unmarshalTestCases = []struct {
+	platErr  *Error
+	protoErr *pe.Error
+}{
+	{
+		&Error{
+			PublicContext:  map[string]string{},
+			PrivateContext: map[string]string{},
+		},
+		&pe.Error{},
+	},
+	{
+		&Error{
+			PublicContext:  map[string]string{},
+			PrivateContext: map[string]string{},
+		},
+		&pe.Error{
+			Code: ErrUnknown,
+		},
+	},
+	{
+		&Error{
+			Code:    ErrTimeout,
+			Message: "omg help plz",
+			PublicContext: map[string]string{
+				"something": "hullo",
+			},
+			PrivateContext: map[string]string{
+				"something else": "bye bye",
+			},
+			Stack: []stack.Frame{
+				{
+					Filename: "some file",
+					Line:     123,
+					Method:   "someMethod",
+				},
+				{
+					Filename: "another file",
+					Line:     1,
+					Method:   "someOtherMethod",
+				},
+			},
+		},
+		&pe.Error{
+			Code:    ErrTimeout,
+			Message: "omg help plz",
+			PublicContext: map[string]string{
+				"something": "hullo",
+			},
+			PrivateContext: map[string]string{
+				"something else": "bye bye",
+			},
+			Stack: []*pe.StackFrame{
+				{
+					Filename: "some file",
+					Line:     123,
+					Method:   "someMethod",
+				},
+				{
+					Filename: "another file",
+					Line:     1,
+					Method:   "someOtherMethod",
+				},
+			},
+		},
+	},
+	{
+		&Error{
+			Code:           ErrForbidden,
+			Message:        "NO. FORBIDDEN",
+			PublicContext:  map[string]string{},
+			PrivateContext: map[string]string{},
+		},
+		&pe.Error{
+			Code:    ErrForbidden,
+			Message: "NO. FORBIDDEN",
+		},
+	},
+}
+
 func TestUnmarshal(t *testing.T) {
-	for _, tc := range interchangableErrorTestCases {
+	for _, tc := range unmarshalTestCases {
 		platErr := Unmarshal(tc.protoErr)
 		assert.Equal(t, tc.platErr.Code, platErr.Code)
 		assert.Equal(t, tc.platErr.Message, platErr.Message)

--- a/errors/marshaling_test.go
+++ b/errors/marshaling_test.go
@@ -13,7 +13,7 @@ func TestMarshalNilError(t *testing.T) {
 	protoError := Marshal(input)
 
 	assert.NotNil(t, protoError)
-	assert.Equal(t, ErrUnknown, protoError.Code)
+	assert.Equal(t, ErrUnknown, int(protoError.Code))
 	assert.NotEmpty(t, protoError.Message)
 }
 

--- a/server/endpoint.go
+++ b/server/endpoint.go
@@ -66,6 +66,12 @@ func cloneTypedPtr(reqType interface{}) interface{} {
 func enrichError(err error, ctx Request, endpoint *Endpoint) *errors.Error {
 	wrappedErr := errors.Wrap(err)
 
+	// @todo perhaps make methods PrivateContext() and PublicContext() that
+	// to deal with nil contexts
+	if wrappedErr.PrivateContext == nil {
+		wrappedErr.PrivateContext = map[string]string{}
+	}
+
 	// @todo an error will probably have a source_request_id or something that we can use to
 	// more reliably make sure this information is only attached once, as the error travels up the service stack
 	if wrappedErr.PrivateContext["service"] == "" {


### PR DESCRIPTION
The root cause of this panic is that typhon errors that come from from rabbitmq as protobufs can have a `nil` Private/PublicContext if they were marshaled with an empty map `map[string]string{}`

This solution breaks the symmetry of marshaling and unmarshaling to proto. It sucks, but unfortunately that's how protobuf works. There's no way to distinguish between something that was marshaled with an empty map and something that was marshaled with a nil map